### PR TITLE
Avoid minifying .min.js, passing config to terser

### DIFF
--- a/lib/jekyll-terser.rb
+++ b/lib/jekyll-terser.rb
@@ -3,10 +3,33 @@ require 'terser'
 
 module Jekyll
   module Terser
-
     class JSFile < Jekyll::StaticFile
-
       @@mtimes = {}
+
+      # Initialize a new JSFile.
+      #   +site+ is the Site
+      #   +base+ is the String path to the <source>
+      #   +dir+ is the String path between <source> and the file
+      #   +name+ is the String filename of the file
+      #   +terser+ is the Terser instance
+      def initialize(site, base, dir, name, terser = nil)
+        super(site, base, dir, name)
+        @site = site
+        @base = base
+        @dir = dir
+        @name = name
+        if terser.nil?
+          if site.config["terser"].nil?
+            options = {}
+          else
+            options = site.config["terser"]
+          end
+          @terser = ::Terser.new(options.transform_keys(&:to_sym))
+
+        else
+          @terser = terser
+        end
+      end
 
       # Obtain destination path.
       #   +dest+ is the String path to the destination dir
@@ -29,7 +52,7 @@ module Jekyll
         FileUtils.mkdir_p(File.dirname(dest_path))
         begin
           content = File.read(path)
-          content = ::Terser.new.compile(content)
+          content = @terser.compile(content)
           File.open(dest_path, 'w') do |f|
             f.write(content)
           end
@@ -39,7 +62,6 @@ module Jekyll
 
         true
       end
-
     end
 
     class TerserGenerator < Jekyll::Generator
@@ -47,7 +69,14 @@ module Jekyll
 
       # Initialize options from site config.
       def initialize(config = {})
-        @options = config["terser"]
+        # check if options is not empty
+        if config["terser"].nil?
+          @options = {}
+        else
+          @options = config["terser"]
+        end
+
+        @terser = ::Terser.new(@options.transform_keys(&:to_sym))
       end
 
       # Jekyll will have already added the *.js files as Jekyll::StaticFile
@@ -55,17 +84,18 @@ module Jekyll
       # JSFile object.
       def generate(site)
         site.static_files.clone.each do |sf|
-          if sf.kind_of?(Jekyll::StaticFile) && sf.path =~ /\.js$/
+          # do not process already minified files
+          if sf.kind_of?(Jekyll::StaticFile) && sf.path =~ /\.js$/ && !sf.path.end_with?(".min.js")
+            puts "Terser: Minifying #{sf.path}"
             site.static_files.delete(sf)
             name = File.basename(sf.path)
             destination = File.dirname(sf.path).sub(site.source, '')
 
-            js_file = JSFile.new(site, site.source, destination, name)
+            js_file = JSFile.new(site, site.source, destination, name, @terser)
             site.static_files << js_file
           end
         end
       end
     end
-
   end
 end


### PR DESCRIPTION
Now avoiding minifying already minified files, getting config properly from `_config.yml`, and creating one single instance of `Terser` to handle all files.